### PR TITLE
chore: bump email-service to 0.0.2

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "email-service"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "dotenv",
  "handlebars",

--- a/backend/email-service/Cargo.toml
+++ b/backend/email-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "email-service"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2024"
 build = "build.rs"
 


### PR DESCRIPTION
### **User description**
### Pull Request Overview

This pull request bumps email-service to 0.0.2.

### Author

Signed-off-by: Andrei Serban - <andrei.serban@brewingbytes.com>


___

### **PR Type**
Other


___

### **Description**
- Bump email-service version from 0.0.1 to 0.0.2


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Version bump to 0.0.2</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/email-service/Cargo.toml

- Updated version field from "0.0.1" to "0.0.2"


</details>


  </td>
  <td><a href="https://github.com/BrewingBytes/Brewget/pull/9/files#diff-42e1d1aa12b2c6e2ecc30445d6890fcdf2ea5ce0006d923af854ad6a2aefc88a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

