### PR TITLE
Move docker compose to use github container registy images

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,8 +22,13 @@ jobs:
         with:
           filters: |
             backend:
-              - '.github/workflows/rust.yaml'
-              - 'backend/**'
+              - '.github/workflows/rust.yml'
+              - 'backend/auth-service/**'
+              - 'backend/email-service/**'
+              - 'backend/proto/**'
+              - 'backend/Cargo.lock'
+              - 'backend/Cargo'
+              - 'backend/rust-toolchain.toml'
       - name: Cache
         if: steps.changes.outputs.backend == 'true'
         uses: actions/cache@v4
@@ -59,8 +64,13 @@ jobs:
         with:
           filters: |
             backend:
-              - '.github/workflows/rust.yaml'
-              - 'backend/**'
+              - '.github/workflows/rust.yml'
+              - 'backend/auth-service/**'
+              - 'backend/email-service/**'
+              - 'backend/proto/**'
+              - 'backend/Cargo.lock'
+              - 'backend/Cargo'
+              - 'backend/rust-toolchain.toml'
       - name: Cache
         if: steps.changes.outputs.backend == 'true'
         uses: actions/cache@v4
@@ -93,8 +103,13 @@ jobs:
         with:
           filters: |
             backend:
-              - '.github/workflows/rust.yaml'
-              - 'backend/**'
+              - '.github/workflows/rust.yml'
+              - 'backend/auth-service/**'
+              - 'backend/email-service/**'
+              - 'backend/proto/**'
+              - 'backend/Cargo.lock'
+              - 'backend/Cargo'
+              - 'backend/rust-toolchain.toml'
       - name: Cache
         if: steps.changes.outputs.backend == 'true'
         uses: actions/cache@v4

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
       - db
       - email-service
     container_name: auth-service
-    image: auth-service:latest
+    image: "ghcr.io/brewingbytes/brewget-auth-service:latest"
     environment:
       - PG_URL=db
       - PG_USERNAME=user-name
@@ -14,17 +14,24 @@ services:
       - JWT_SECRET=secret
       - JWT_EXPIRES_IN=86400
       - JWT_MAX_AGE=86400
+      - AUTH_HTTP_PORT=8000
+      - EMAIL_HOSTNAME=http://email-service
+      - EMAIL_GRPC_PORT=9001
+      - FRONTEND_HOSTNAME=http://localhost
     networks:
       - db
+    ports:
+      - 8000:8000
   email-service:
     container_name: email-service
-    image: email-service:latest
+    image: "ghcr.io/brewingbytes/brewget-email-service:latest"
     environment:
       - SMTP_EMAIL=noreply@brewingbytes.com
       - SMTP_NAME=BrewGet
       - SMTP_RELAY=smtp.example.com
       - SMTP_USERNAME=smtp-user
       - SMTP_PASSWORD=smtp-password
+      - EMAIL_GRPC_PORT=9001
     networks:
       - db
   db:


### PR DESCRIPTION
### **User description**
### Pull Request Overview

This pull request moves docker compose to use ghcr images.

### Author

Signed-off-by: Andrei Serban - <andrei.serban@brewingbytes.com>


___

### **PR Type**
Enhancement


___

### **Description**
- Update Docker Compose to use GitHub Container Registry images

- Add new environment variables for service configuration

- Expose auth-service port 8000 for external access


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Local Images"] --> B["GHCR Images"]
  C["Basic Config"] --> D["Enhanced Config"]
  B --> E["auth-service:8000"]
  B --> F["email-service"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yaml</strong><dd><code>Migrate to GHCR images with enhanced configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/docker-compose.yaml

<ul><li>Replace local Docker images with GitHub Container Registry (<code>ghcr.io</code>) <br>images<br> <li> Add environment variables for HTTP port, email hostname, and frontend <br>hostname<br> <li> Expose port 8000 for auth-service external access<br> <li> Update email-service configuration with GRPC port setting</ul>


</details>


  </td>
  <td><a href="https://github.com/BrewingBytes/Brewget/pull/24/files#diff-e82d83fb2061d91bd2a75743bb98569311d56d8defbc94a7cf1659c007837ce1">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

