### PR TITLE
fix: login takes a long time, due to settings loading

### DIFF
--- a/changelogs/frontend-CHANGELOG.md
+++ b/changelogs/frontend-CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Frontend will be documented in this file.
 ## [Unreleased]
 ### Fixed
 - Fix Turnstile captcha not resetting on failed login/register attempts
+- Fix login taking too long due to waiting for settings load
 
 ## [0.0.10] - 2025-10-31
 ### Added

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -68,11 +68,16 @@ export const useAuthStore = defineStore(
 
       // Load user settings and apply language preference
       const settingsStore = useSettingsStore();
-      await settingsStore.loadSettings();
-
-      if (settingsStore.settings && SUPPORTED_LOCALES.includes(settingsStore.settings.language as SupportedLocale)) {
-        i18n.global.locale.value = settingsStore.settings.language as SupportedLocale;
-      }
+      settingsStore.loadSettings().then(() => {
+        if (settingsStore.settings && SUPPORTED_LOCALES.includes(settingsStore.settings.language as SupportedLocale)) {
+          i18n.global.locale.value = settingsStore.settings.language as SupportedLocale;
+        }
+      }).catch(() => {
+        useToastStore().showTranslationKey(
+          "settings.failed_to_load",
+          ToastSeverity.ERROR,
+        );
+      });
 
       router.push("/");
 

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -72,11 +72,6 @@ export const useAuthStore = defineStore(
         if (settingsStore.settings && SUPPORTED_LOCALES.includes(settingsStore.settings.language as SupportedLocale)) {
           i18n.global.locale.value = settingsStore.settings.language as SupportedLocale;
         }
-      }).catch(() => {
-        useToastStore().showTranslationKey(
-          "settings.failed_to_load",
-          ToastSeverity.ERROR,
-        );
       });
 
       router.push("/");


### PR DESCRIPTION
### **User description**
### Pull Request Overview

This pull request fixes the long time to login.
Closes #109 

### Author

Signed-off-by: Andrei Serban - <andrei.serban@brewingbytes.com>


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Convert settings loading from await to non-blocking promise chain

- Prevent login delay by loading settings asynchronously after redirect

- Add error handling for failed settings load with user notification


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Login Request"] --> B["Set Bearer Token"]
  B --> C["Async Load Settings"]
  C --> D["Apply Language Preference"]
  C --> E["Show Error Toast on Failure"]
  D --> F["Redirect to Home"]
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auth.ts</strong><dd><code>Convert settings loading to non-blocking promise</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/stores/auth.ts

<ul><li>Changed <code>await settingsStore.loadSettings()</code> to non-blocking promise <br>chain with <code>.then()</code> and <code>.catch()</code><br> <li> Moved language preference application inside promise callback to <br>execute after settings load completes<br> <li> Added error handling with toast notification when settings fail to <br>load<br> <li> Allows router redirect to execute immediately without waiting for <br>settings load</ul>


</details>


  </td>
  <td><a href="https://github.com/BrewingBytes/Brewget/pull/114/files#diff-5a75fa8edd10425ced77b50ed23ef23b22a49b48e9c23d72b1ead220368daf86">+10/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

